### PR TITLE
LB-1394 Remove lint task from Gruntfile and fix indentation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
 
     // Load all grunt task declared in package.json
     require('load-grunt-tasks')(grunt);
-    
+
     // var server =  grunt.option('server') || 'http://localhost:9000',
     //     port = server.
 
@@ -20,18 +20,17 @@ module.exports = function(grunt) {
 
     // Install the jshint pre-commit hook
     grunt.registerTask('install-hook', function () {
-            var fs = require('fs');
+        var fs = require('fs');
 
-            // my precommit hook is inside the repo as /hooks/pre-commit
-            // copy the hook file to the correct place in the .git directory
-            grunt.file.copy('hooks/pre-commit', '.git/hooks/pre-commit');
+        // my precommit hook is inside the repo as /hooks/pre-commit
+        // copy the hook file to the correct place in the .git directory
+        grunt.file.copy('hooks/pre-commit', '.git/hooks/pre-commit');
 
-            // chmod the file to readable and executable by all
-            fs.chmodSync('.git/hooks/pre-commit', '755');
-        });
+        // chmod the file to readable and executable by all
+        fs.chmodSync('.git/hooks/pre-commit', '755');
+    });
 
     grunt.registerTask('server', ['express:dev', 'open:dev', 'watch:express']);
-    grunt.registerTask('lint', ['watch:hint-all']);
     grunt.registerTask('hint', ['jshint:all']);
     grunt.registerTask('build', ['jshint:all','requirejs']);
 


### PR DESCRIPTION
The lint task is not necessary, it can be call with watch:hint-all (or watch:hint-own, watch:hint-libs)
