### PR TITLE
LB-1564 Updated posts are rendered inside an extra li el

### DIFF
--- a/gui-resources/scripts/js/views/base-view.js
+++ b/gui-resources/scripts/js/views/base-view.js
@@ -53,6 +53,14 @@ define([
             return this.__manager__.parent;
         },
 
+        // Fix LB-1564
+        // We set some view properties for Backbone.layoutManager to work as
+        // if the view had been rendered
+        fakeViewRendering: function() {
+            this.hasRendered      = true;
+            this.__manager__.noel = true;
+        },
+
         events: {},
 
         // Add events to the view only if we are in the client.

--- a/gui-resources/scripts/js/views/post.js
+++ b/gui-resources/scripts/js/views/post.js
@@ -12,6 +12,7 @@ define([
         // Set el to the top level element from the template
         // instead of default behaviour of inserting a div element.
         el: false,
+
         // Where we cache some data.
         //   for now is used for cacheing the itemName after the compilation of it.
         propertiesObj: {
@@ -48,10 +49,13 @@ define([
             }
             return data;
         },
+
         alreadyRendered: function() {
+            this.fakeViewRendering();
             utils.dispatcher.trigger('before-render.post-view', this);
             utils.dispatcher.trigger('after-render.post-view', this);
         },
+
         beforeRender: function() {
             utils.dispatcher.trigger('before-render.post-view', this);
         },


### PR DESCRIPTION
Fix for bug: html for updated posts is rendered twice (a "li" with new content inside the old "li" element)
